### PR TITLE
Escape all boolean strings

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -927,8 +927,12 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "true" | "True" | "TRUE" => Some(true),
-        "false" | "False" | "FALSE" => Some(false),
+        "y" | "Y" | "yes" | "Yes" | "YES" | "on" | "On" | "ON" | "true" | "True" | "TRUE" => {
+            Some(true)
+        }
+        "n" | "N" | "no" | "No" | "NO" | "off" | "Off" | "OFF" | "false" | "False" | "FALSE" => {
+            Some(false)
+        }
         _ => None,
     }
 }

--- a/src/de.rs
+++ b/src/de.rs
@@ -927,12 +927,8 @@ fn parse_null(scalar: &[u8]) -> Option<()> {
 
 fn parse_bool(scalar: &str) -> Option<bool> {
     match scalar {
-        "y" | "Y" | "yes" | "Yes" | "YES" | "on" | "On" | "ON" | "true" | "True" | "TRUE" => {
-            Some(true)
-        }
-        "n" | "N" | "no" | "No" | "NO" | "off" | "Off" | "OFF" | "false" | "False" | "FALSE" => {
-            Some(false)
-        }
+        "true" | "True" | "TRUE" => Some(true),
+        "false" | "False" | "FALSE" => Some(false),
         _ => None,
     }
 }
@@ -1094,6 +1090,15 @@ pub(crate) fn digits_but_not_number(scalar: &str) -> bool {
     // the YAML 1.2 spec. https://yaml.org/spec/1.2/spec.html#id2761292
     let scalar = scalar.strip_prefix(['-', '+']).unwrap_or(scalar);
     scalar.len() > 1 && scalar.starts_with('0') && scalar[1..].bytes().all(|b| b.is_ascii_digit())
+}
+
+pub(crate) fn is_bool_str(scalar: &str) -> bool {
+    eprintln!("checking if scalar {} needs single quotes", scalar);
+    match scalar {
+        "y" | "Y" | "yes" | "Yes" | "YES" | "on" | "On" | "ON" | "true" | "True" | "TRUE" | "n"
+        | "N" | "no" | "No" | "NO" | "off" | "Off" | "OFF" | "false" | "False" | "FALSE" => true,
+        _ => false,
+    }
 }
 
 pub(crate) fn visit_int<'de, V>(visitor: V, v: &str) -> Result<Result<V::Value>, V>

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -342,6 +342,8 @@ where
             fn visit_str<E>(self, v: &str) -> Result<Self::Value, E> {
                 Ok(if crate::de::digits_but_not_number(v) {
                     ScalarStyle::SingleQuoted
+                } else if crate::de::is_bool_str(v) {
+                    ScalarStyle::SingleQuoted
                 } else {
                     ScalarStyle::Any
                 })

--- a/tests/test_serde.rs
+++ b/tests/test_serde.rs
@@ -297,18 +297,30 @@ fn test_strings_needing_quote() {
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
     struct Struct {
         boolean: String,
+        yes_scalar: String,
+        no_scalar: String,
+        on_scalar: String,
+        off_scalar: String,
         integer: String,
         void: String,
         leading_zeros: String,
     }
     let thing = Struct {
         boolean: "true".to_owned(),
+        yes_scalar: "yes".to_owned(),
+        no_scalar: "no".to_owned(),
+        on_scalar: "on".to_owned(),
+        off_scalar: "off".to_owned(),
         integer: "1".to_owned(),
         void: "null".to_owned(),
         leading_zeros: "007".to_owned(),
     };
     let yaml = indoc! {"
         boolean: 'true'
+        yes_scalar: 'yes'
+        no_scalar: 'no'
+        on_scalar: 'on'
+        off_scalar: 'off'
         integer: '1'
         void: 'null'
         leading_zeros: '007'


### PR DESCRIPTION
This PR makes sure that all boolean strings (https://yaml.org/type/bool.html) are escaped when serializing structs.
The downside of this approach is, that a struct like 
```rust
let x = Struct { yes: "yes" };
```
turns into 
```yaml
'yes': 'yes'
```
I haven't yet figured out a way to only do this for scalars that are values in a mapping, and not for keys.